### PR TITLE
update link to discuss asciidoc questions, remove ruby version note a…

### DIFF
--- a/src/a_few_basics.adoc
+++ b/src/a_few_basics.adoc
@@ -9,13 +9,9 @@ For details and additional options, see:
  * AsciiDoc http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[quick reference].
  * Asciidoctor http://asciidoctor.org/docs/user-manual/[user manual].
 
-In addition, you can ask questions in the https://discuss.asciidoctor.org/[Asciidoctor discussion list].
-
-As is true of any complex process, AsciiDoc/Asciidoctor has some quirks. Please be certain to use the templates, as the templates provide you with files that result in fully featured PDF output.
+In addition, you can ask questions in <https://asciidoctor.zulipchat.com/>
 
 Best practice is to test the PDF build frequently to ensure that you have not accidentally introduced something that breaks the build.
-
-WARNING: PDF generation requires the use of Ruby 2.7.2.
 
 [NOTE]
 ====


### PR DESCRIPTION
…s it doesn't apply anymore

I just removed the ruby version as it's a moving target:

```
~/rvi/riscv/docs-dev-guide on dev/kbroch/zulip-ruby-ver:main ⇡1 ?5                                                                                                                                                         Ruby 3.1.6 at 01:45:35 PM
❯ docker run --rm -v /Users/kbroch/rvi/riscv/docs-dev-guide:/build -w /build riscvintl/riscv-docs-base-container-image:latest /bin/sh -c "ruby --version"
```