### PR TITLE
Added documentation of some best-practices for releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /build/*
 /images/stem*
+git_sha.adoc
+images
+.*.swp

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ build-no-container:
 	@echo "Build completed successfully."
 
 clean:
-	@echo "Cleaning up generated files..."
-	rm -rf $(BUILD_DIR)
+	@if command -v docker >/dev/null 2>&1 ; then \
+	  echo "Cleaning up generated files via Docker..."; \
+	  $(DOCKER_RUN) /bin/sh -c "rm -rf $(BUILD_DIR)"; \
+	else \
+	  echo "Cleaning up generated files..."; \
+	  rm -rf $(BUILD_DIR); \
+	fi
 	@echo "Cleanup completed."

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,12 @@
 # the Doc Template for RISC-V Extensions.
 
 DATE ?= $(shell date +%Y-%m-%d)
-VERSION ?= v1.0.0
-REVMARK ?= Draft
 DOCKER_RUN := docker run --rm -v ${PWD}:/build -w /build \
 riscvintl/riscv-docs-base-container-image:latest
 
+# DO NOT SPECIFY A VERSION OR REVMARK HERE! The revision version and mark
+# (draft/release/etc) should be marked via the :revnumber: and :revremark: fields
+# in the source document itself.
 SRC_DIR := ./src
 BUILD_DIR := build
 HEADER_SOURCE := $(SRC_DIR)/docs-dev-guide.adoc
@@ -27,13 +28,11 @@ ASCIIDOCTOR_HTML := asciidoctor
 OPTIONS := --trace \
            -a compress \
            -a mathematical-format=svg \
-           -a revnumber=${VERSION} \
-           -a revremark=${REVMARK} \
            -a revdate=${DATE} \
            -a pdf-fontsdir=docs-resources/fonts \
            -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
            -D $(BUILD_DIR) \
-           --failure-level=ERROR
+           --failure-level=WARNING
 REQUIRES := --require=asciidoctor-bibtex \
             --require=asciidoctor-diagram \
             --require=asciidoctor-mathematical

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ riscvintl/riscv-docs-base-container-image:latest
 SRC_DIR := ./src
 BUILD_DIR := build
 HEADER_SOURCE := $(SRC_DIR)/docs-dev-guide.adoc
+GIT_SHA_DOC := $(SRC_DIR)/git_sha.adoc
 
 ASCIIDOCTOR_PDF := asciidoctor-pdf
 ASCIIDOCTOR_HTML := asciidoctor
 OPTIONS := --trace \
            -a compress \
            -a mathematical-format=svg \
-           -a revdate=${DATE} \
            -a pdf-fontsdir=docs-resources/fonts \
            -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
            -D $(BUILD_DIR) \
@@ -39,7 +39,12 @@ REQUIRES := --require=asciidoctor-bibtex \
 
 .PHONY: all build clean build-container build-no-container
 
-all: build
+all: $(GIT_SHA_DOC) build
+
+$(GIT_SHA_DOC): .FORCE
+	echo ":git_sha: $$(git describe --dirty --always)" > $@
+.PHONY: .FORCE
+.FORCE:	# To force the GIT_SHA_DOC to get rebuilt each time
 
 build:
 	@echo "Checking if Docker is available..."

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ build-no-container:
 
 clean:
 	@if command -v docker >/dev/null 2>&1 ; then \
-	  echo "Cleaning up generated files via Docker..."; \
-	  $(DOCKER_RUN) /bin/sh -c "rm -rf $(BUILD_DIR)"; \
+		echo "Cleaning up generated files via Docker..."; \
+		$(DOCKER_RUN) /bin/sh -c "rm -rf $(BUILD_DIR)"; \
 	else \
-	  echo "Cleaning up generated files..."; \
-	  rm -rf $(BUILD_DIR); \
+		echo "Cleaning up generated files..."; \
+		rm -rf $(BUILD_DIR); \
 	fi
 	@echo "Cleanup completed."

--- a/src/build-infrastructure.adoc
+++ b/src/build-infrastructure.adoc
@@ -1,0 +1,70 @@
+== Build Infrastructure
+
+Most RISC-V AsciiDoc documents use a `Makefile` to simplify the build process. For many documents, building the PDF and HTML flavors of the documents is as simple as going into the root directory of the document repository and typing `make`.
+
+If Docker is already installed, the `Makefile` will invoke `docker` for the build process. Otherwise, it will build natively.
+
+As an author of a document, there are some conventions to be aware of:
+
+- The version, date, and state (draft, frozen, ratified) of the document should be specified in the `.adoc` file for that document via use of the `:revnumber:` and `:revremark:` keywords. An example usage is the following:
+
+[source,cmd]
+----
+...
+:revnumber: v0.5.1
+:revremark: Draft
+...
+----
+
+
+[NOTE]
+====
+The version, date, and state (draft/frozen/ratified) of the specification
+should be specified *only* in the appropriate `.adoc` file in that repository.
+Some of the document repositories currently use an override in the `Makefile`,
+which can lead to the `Makefile` and the source document claiming different
+revision numbers, dates, and states.
+====
+
+- When preparing to release a specification, it is incumbent to ensure the
+release is fully reproducible and self-documenting. To maintain this, please
+follow these steps for a release:
+.. Update the revision number `:revnumber:` in the source document to reflect
+the release number. This may contain any text (except carriage returns), like
+the following examples. There are no currently agreed-upon conventions for
+this, but please ensure your tag is meaningful for others.
+*** `v0.2`
+*** `v0.2 (with draft of potential Zxyz additions)`
+*** `2025-01-26`
+*** `v1.0.0-draft`
+*** `v1.0.0-rc2`
+*** `v1.0.0`
+*** `v1.0.0-ratified`
+.. Update the revision remark `:revremark:` in the source document to reflect the specification state. Some examples include:
+*** `This document is in development. Assume everything can change.`
+*** `draft`
+*** `This document is in draft state. Change should be expected.`
+*** `This document is in stable state. Assume everything could change.`
+*** `Frozen`
+*** `Release candidate`
+*** `Ratified`
+.. If desired, update the date field `:revdate:` in the source document. If
+left unspecified, no date will be printed on the revision subtitle. The
+recommended date format is YYYY-MM-DD.
+.. Perform a `make clean all` to ensure everything builds cleanly.
+.. Use `git tag <tag-name>` to tag the repository so this build can be perfectly reproduced. Some example tag names:
+*** `riscv-Zxyz-v1.0.0-rc2`
+*** `riscv-Zxyz-v20240411-draft`
+*** `v0.4`
+*** `v0.6-public-review`
+.. Push your changes to upstream.
+.. Perform a `make clean all` to perform the official build off of the tag.
+.. Publish the document appropriately.
+
+- To help ensure clean "coding" in the documentation, it can be useful to turn
+Asciidoctor's error checking to the more strict `--failure-level=WARNING` such
+that any warnings during the document build process are considered fatal
+errors. This can be adjusted by altering the `asciidoc` invocation in the `Makefile`.
+
+This document repository currently adheres to all of these conventions, and
+may be a useful starting point for other specifications.

--- a/src/build-infrastructure.adoc
+++ b/src/build-infrastructure.adoc
@@ -59,7 +59,7 @@ recommended date format is YYYY-MM-DD.
 *** `v0.6-public-review`
 .. Push your changes to upstream.
 .. Perform a `make clean all` to perform the official build off of the tag.
-.. Inspect the final PDF to ensure the git SHA tag does not contain `dirty` as part of the name; if so, there are some uncommitted changes in your working repository.
+.. Inspect the final PDF(s) to ensure the git SHA tag does not contain `dirty` as part of the name; if so, there are some uncommitted changes in your working repository. If not, then commit your changes and re-tag the release and try again.
 .. Publish the document appropriately.
 
 - To help ensure clean "coding" in the documentation, it can be useful to turn

--- a/src/build-infrastructure.adoc
+++ b/src/build-infrastructure.adoc
@@ -59,6 +59,7 @@ recommended date format is YYYY-MM-DD.
 *** `v0.6-public-review`
 .. Push your changes to upstream.
 .. Perform a `make clean all` to perform the official build off of the tag.
+.. Inspect the final PDF to ensure the git SHA tag does not contain `dirty` as part of the name; if so, there are some uncommitted changes in your working repository.
 .. Publish the document appropriately.
 
 - To help ensure clean "coding" in the documentation, it can be useful to turn

--- a/src/docs-dev-guide.adoc
+++ b/src/docs-dev-guide.adoc
@@ -2,6 +2,7 @@
 = Authoring and Editing RISC-V Specifications
 :description: A working template for documenting RISC-V architecture in asciidoc
 :company: RISC-V.org
+:revnumber: v0.2.0-example
 :revremark: Pre-release version
 //development: assume everything can change
 //stable: assume everything could change

--- a/src/docs-dev-guide.adoc
+++ b/src/docs-dev-guide.adoc
@@ -1,12 +1,24 @@
 [[riscv-authoring]]
 = Authoring and Editing RISC-V Specifications
+//:title-logo-image: image:risc-v_logo.png[pdfwidth=3.25in,align=center]
 :description: A working template for documenting RISC-V architecture in asciidoc
 :company: RISC-V.org
-:revnumber: v0.2.0-example
+// Grab the auto-generated git SHA.
+include::git_sha.adoc[]
+// IMPORTANT: Each author should make sure that revnumber, revdate, and revremark
+// are set to proper values. Whenever the status of a spec changes, or a new
+// release is done, these should be updated to reflect that. NO OVERRIDES of
+// these values through the Makefile or command-line should be done, to ensure
+// that the proper versioning is captured in the git commits.
+// See also the Build Infrastructure section near the end of this document, or
+// src/build-infrastructure.adoc
+:revnumber: v0.2.0-example (git SHA {git_sha})
+// If desired, uncomment this and hard-code a date.
+//:revdate: today
 :revremark: Pre-release version
 //development: assume everything can change
 //stable: assume everything could change
-//frozen: of you implement this version you assume the risk that something might change because of the public review cycle  but we expect little to no change.
+//frozen: if you implement this version you assume the risk that something might change because of the public review cycle  but we expect little to no change.
 //ratified: you can implement this and be assured nothing will change. if something needs to change due to an errata or enhancement, it will come out in a new extension. we do not revise extensions.
 :revinfo:
 :url-riscv: http://riscv.org
@@ -79,6 +91,8 @@ include::writing.adoc[]
 include::word-usage.adoc[]
 
 include::linting.adoc[]
+
+include::build-infrastructure.adoc[]
 
 //Note that the index must precede the bibliography for both to work within the same book.
 include::index.adoc[]


### PR DESCRIPTION
Added documentation of how the build process works, and also some conventions that authors should follow, including a checklist for a release to ensure that release is fully reconstructible. The repo was also cleaned up so that it follows the suggested rules -- no overrides in the Makefile for fields that should be in the adoc files instead, WARNINGs are considered fatal, etc.