### PR TITLE
Add GitHub Actions workflow for site deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,190 @@
+---
+name: Publish site to GitHub Pages
+
+# Publish this specification as a standalone Antora HTML site on this
+# repository's own GitHub Pages site, alongside the release PDF.
+#
+# Relationship to the RISC-V production site: docs.riscv.org is assembled by the
+# central playbook (github.com/riscv-admin/antora.riscv.org) from 20+ content
+# sources, of which this repo is one -- that site is canonical for RISC-V specs
+# and is NOT built here (see ANTORA.md "Production model"). What this workflow
+# publishes is a per-repo copy of the same content, which is the primary output
+# for a repo seeded from this template but is a convenience for specs that also
+# ship centrally. The build itself lives in scripts/build-pages-site.sh so it can
+# be reproduced locally.
+#
+# One-time setup in a repo seeded from this template: a repository admin must set
+# Settings -> Pages -> Source to "GitHub Actions", ideally before the first push
+# to main -- this workflow runs on every push to main, not only on tags, so until
+# Pages exists each push leaves a failed run behind. The configure-pages step
+# below asks for that automatically (enablement: true), but GITHUB_TOKEN is
+# refused with "Resource not accessible by integration": creating a Pages site is
+# an admin-level operation the Actions app cannot perform on a repo that has
+# none, regardless of the pages: write grant below. That is a limitation of the
+# Actions token, NOT an org policy -- there is no org setting to change. Once the
+# site exists, enablement is a no-op.
+#
+# Set that source directly to "GitHub Actions". If a repo is left on "Deploy from
+# a branch" first, GitHub queues a run of its built-in pages-build-deployment
+# workflow that survives the switch and can deploy AFTER the first Actions
+# deployment, overwriting the site with the repo root -- a live 404 from a run
+# that reported success. Re-run this workflow to recover; it does not recur.
+
+on:
+  # Called by version-bot.yml immediately after a release tag is cut, so the
+  # Pages site follows a release without depending on the tag push firing an
+  # event (it cannot: version-bot tags with GITHUB_TOKEN on purpose).
+  workflow_call:
+    inputs:
+      release_version:
+        description: Release version to publish (e.g. v0.62). Must already be tagged.
+        required: true
+        type: string
+
+  push:
+    # Publish the tip of main as the `dev` version, so the site tracks merged
+    # content instead of standing still between releases. build-pages-site.sh
+    # resolves an untagged build to <latest>-<sha> and publishes it under the
+    # short fixed label `dev` (DEV_VERSION_LABEL), so repeated merges refresh one
+    # path rather than orphaning a new /<sha>/ on every commit.
+    branches:
+      - main
+    tags:
+      - v*
+  # Republish on demand -- e.g. after fixing content on a release, or to bring up
+  # the site in a freshly seeded repo without waiting for the first tag.
+  workflow_dispatch:
+
+# contents: read      -- checkout only; this workflow never writes to the repo.
+#                        In particular it does NOT persist the version stamp: the
+#                        stamp is applied to the working tree for the build and
+#                        thrown away. Getting it onto main stays build-pdf.yml's
+#                        job, which opens a review PR for it.
+# pages/id-token      -- required by actions/deploy-pages (OIDC deployment).
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two publishes race for the single Pages deployment. Queue rather
+# than cancel: a cancelled release publish would leave the previous version live
+# with no indication that the newer one never shipped.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # GitHub Pages is not available on private repositories outside GitHub Team
+    # and Enterprise Cloud. A template consumer working in a private repo should
+    # skip cleanly rather than see a failed release run; on Team/Enterprise,
+    # delete this condition to publish privately.
+    if: ${{ !github.event.repository.private }}
+
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    # Local Kroki server for asciidoctor-kroki (wavedrom etc.). Matches the
+    # kroki-server-url: http://localhost:9870 attribute in antora-playbook.yml,
+    # which the generated Pages playbook inherits. Pinned for reproducible
+    # diagram output -- keep in sync with docker-compose.yml and
+    # validate-content-source.yml.
+    services:
+      kroki:
+        image: yuzutech/kroki:0.31.1
+        ports:
+          - 9870:8000
+
+    steps:
+      # fetch-depth: 0 -- scripts/release-info.sh resolves the version from tags,
+      # and the site build inspects every release tag to decide which versions to
+      # publish. submodules -- docs-resources supplies the cover logo.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # When version-bot calls us, publish the TAGGED commit.
+          ref: ${{ inputs.release_version || github.ref }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Antora tooling
+        run: npm ci
+
+      # The service container is "started" before it can serve; without this the
+      # Antora build can race Kroki's JVM startup and fail on diagram rendering.
+      # Polled from the runner (which has curl) rather than via a container
+      # healthcheck, since the Kroki image ships no HTTP client to probe itself.
+      - name: Wait for Kroki
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:9870/health >/dev/null 2>&1; then
+              echo "Kroki is up after ${i} attempt(s)."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Kroki did not become healthy within 60s"
+          exit 1
+
+      # Enables Pages on first run (enablement: true) and reports the base URL
+      # the site will be served from. Project sites live under /<repo>/, not at
+      # the domain root, so Antora needs this for the sitemap and canonical URLs.
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      # Version/date resolution mirrors build-pdf.yml so the published site
+      # version matches the released PDF. On a version-bot call or a tag push the
+      # tag IS the version;
+      # the date is taken from the tagged commit rather than "today" so that
+      # re-running this workflow later republishes an identical site. A manual
+      # run -- and a push to main -- leaves both empty, and the script falls back
+      # to release-info.sh, which yields the <latest>-<sha> dev version.
+      - name: Resolve release version
+        id: release
+        run: |
+          set -euo pipefail
+          tag=""
+          if [ -n "${{ inputs.release_version }}" ]; then
+            tag="${{ inputs.release_version }}"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            tag="${{ github.ref_name }}"
+          fi
+
+          if [ -n "$tag" ]; then
+            version="$tag"
+            date="$(git log -1 --format=%cs "$tag")"
+          else
+            version=""
+            date=""
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "date=$date" >> "$GITHUB_OUTPUT"
+          echo "Publishing version='${version:-<from tags>}' date='${date:-<today>}'"
+
+      - name: Build site
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          DATE: ${{ steps.release.outputs.date }}
+        run: ./scripts/build-pages-site.sh "${{ steps.pages.outputs.base_url }}"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/pages-site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This workflow publishes the site to GitHub Pages, handling both release and development versions. It includes steps for setting up the environment, building the site, and deploying it.