### PR TITLE
Build the Antora site in the Pages workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,5 +1,10 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+# Builds the Antora site for this repository and deploys it to GitHub Pages at
+# https://riscv.github.io/docs-dev-guide/.
+#
+# This is a standalone preview of THIS repository. The authoritative RISC-V
+# documentation site is assembled by the central playbook at
+# riscv-admin/antora.riscv.org, which consumes this repo as a content source.
+name: Deploy Antora site to Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -22,22 +27,63 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install Antora
+        run: npm ci
+
+      # antora-playbook.yml is the local preview playbook: it points site.url at
+      # the repo and Kroki at the docker-compose server on localhost. Neither is
+      # reachable from a runner, so override both here rather than editing the
+      # playbook and breaking local preview.
+      - name: Build site
+        run: |
+          ./node_modules/.bin/antora --fetch antora-playbook.yml \
+            --url https://riscv.github.io/docs-dev-guide \
+            --attribute kroki-server-url=https://kroki.io
+
+      # The shared RISC-V UI bundle hardcodes links to /home/index.html -- the
+      # landing page of the central site's `home` component, which a standalone
+      # preview does not build. Emit a redirect there so the header logo and the
+      # "RISC-V Specifications" nav link resolve instead of 404ing.
+      - name: Add home redirect for the shared UI bundle
+        run: |
+          mkdir -p build/site/home
+          cat > build/site/home/index.html <<'HTML'
+          <!DOCTYPE html>
+          <meta charset="utf-8">
+          <script>location="../index.html"</script>
+          <meta http-equiv="refresh" content="0; url=../index.html">
+          <meta name="robots" content="noindex">
+          <title>Redirect Notice</title>
+          <p>The RISC-V Authoring and Editing Guide is <a href="../index.html">here</a>.</p>
+          HTML
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/site
+
   deploy:
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Upload entire repository
-          path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

https://riscv.github.io/docs-dev-guide/ returns **404**, even though every Pages
deploy reports success.

`.github/workflows/static.yml` was never updated by #165. It is still the stock
static-content template:

```yaml
- name: Upload artifact
  uses: actions/upload-pages-artifact@v3
  with:
    # Upload entire repository
    path: '.'
```

No Antora build runs at all. The workflow checks out the repo, tars up the root
directory verbatim and ships it to Pages. Since there is no `index.html` at the
repo root, Pages has nothing to serve. The runs are green because uploading a
directory without an index is not an error.

`antora-playbook.yml`, `antora.yml`, `package.json` and `modules/ROOT/**` all
landed in #165, but nothing in CI invokes them — the only entry point that
shipped is `npm run preview`, which is local-only.

## Fix

One file. Add a `build` job that installs the pinned toolchain with `npm ci`,
runs the playbook, and uploads `build/site` instead of the repo root.

`antora-playbook.yml` is explicitly documented as a local preview playbook:
`site.url` points at the GitHub repo, and `kroki-server-url` at the
docker-compose server on `localhost:9870`. Neither is reachable from a runner,
so both are overridden on the Antora command line rather than by editing the
playbook — local preview via `npm run preview` is unchanged.

The shared UI bundle also hardcodes links to `/home/index.html`, the landing
page of the central site's `home` component, which a standalone preview does not
build. Without a redirect there, the header logo and the "RISC-V Specifications"
nav link 404 on all 16 pages, so the workflow emits one.

### Why not Makefile targets

`package.json` + `package-lock.json` pin `@antora/cli` 3.1.15 and
`asciidoctor-kroki` 0.18.1. `npm ci` reuses those exact versions and stays
reproducible.

## Verification

Ran the CI steps against a pristine clone of this branch:

- `npm ci` then the playbook build → **exit 0**
- `build/site/index.html` present, redirecting to `docs-guide/v0.20/index.html`
  with the correct canonical URL
- link sweep over the built site: `home/index.html` now resolves; the remaining
  `/docs-dev-guide/_/...` references on `404.html` are root-relative and correct
  once deployed

## Out of scope — pre-existing, worth a follow-up

`antora.yml` sets `page-pdf_url` to an absolute URL, but the UI bundle expects a
filename and path-joins it, so the PDF sidebar link renders on every page as:

```
href="/reference/docs-guide/v0.20/https://github.com/riscv/docs-dev-guide/releases/tag/v0.2.0-example"
```

Broken twice over — mangled URL, and missing the `/docs-dev-guide` prefix. It
arrived with #165 and is unrelated to publishing, so it is left alone here.

Separately, `.gitignore` and `package.json` reference `scripts/build-pages-site.sh`,
`/antora-pages-playbook.yml` and `ANTORA.md`, none of which exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
