### PR TITLE
Restore the template's front and back matter

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -14,3 +14,9 @@
 * xref:linting.adoc[Linting]
 * xref:build-infrastructure.adoc[Build Infrastructure]
 * xref:bibliography.adoc[Bibliography]
+// Back matter. Appended rather than placed up front (where the template puts
+// them) so the chapter line numbers above do not shift: the central playbook's
+// numbering_rules entry for this component keys chapters off LINE NUMBERS in
+// this file. See MIGRATION.md Step 11.
+* xref:contributors.adoc[Contributors]
+* xref:copyright.adoc[Copyright and license information]

--- a/modules/ROOT/pages/author-quickstart.adoc
+++ b/modules/ROOT/pages/author-quickstart.adoc
@@ -105,8 +105,8 @@ src/spec-sample.adoc                    <9>
 <1> Images used in the spec. These are referenced from the chapter files and included in both PDF and HTML output.
 <2> Site landing / cover page. HTML-only -- **not** part of the PDF. Follow the instructions in this file to update the content.
 <3> The introduction chapter. Becomes "Chapter 1" in the PDF.
-<4> Front matter that lists contributors. HTML only -- **not** part of the PDF. Follow the instructions in this file to update the content.
-<5> Copyright and license information. HTML only -- **not** part of the PDF. Follow the instructions in this file to update the content.
+<4> Front matter that lists contributors. Included in both PDF and HTML: the site navigation renders it as a page, and the PDF assembler includes it as a `[preface]` ahead of the first chapter. Follow the instructions in this file to update the content.
+<5> Copyright and license information. Included in both PDF and HTML, the same way as the contributors file. Follow the instructions in this file to update the content.
 <6> Bibliography main page. Included in both PDF and HTML and uses the bibliography database (`riscv-spec.bib`) to render the references.
 <7> Bibliography database.
 <8> HTML navigation file -- Update references to your chapter files here. This is the site navigation that builds the HTML output.

--- a/modules/ROOT/pages/contributors.adoc
+++ b/modules/ROOT/pages/contributors.adoc
@@ -1,0 +1,16 @@
+== Contributors
+
+This guide has been contributed to directly or indirectly by:
+
+[%hardbreaks]
+* Kevin Broch
+* Stephano Cetola
+* Paul A. Clarke
+* Brian Grayson
+* Jeff Osier-Mixon
+* Kersten Richter
+* Elisa Sawyer
+* Jeff Scheel
+* Josh Scheid
+* Rafael Sene
+* Bill Traynor

--- a/modules/ROOT/pages/copyright.adoc
+++ b/modules/ROOT/pages/copyright.adoc
@@ -1,0 +1,9 @@
+[preface]
+== Copyright and license information
+
+This documentation is licensed under the Creative Commons
+Attribution 4.0 International License (CC-BY 4.0). The full
+license text is available at
+https://creativecommons.org/licenses/by/4.0/.
+
+Copyright 2026 by RISC-V International.

--- a/src/docs-dev-guide.adoc
+++ b/src/docs-dev-guide.adoc
@@ -9,11 +9,13 @@ ifndef::revnumber[:revnumber: v0.0]
 ifndef::revdate[:revdate: 1970-01-01]
 ifndef::spec_short[:spec_short: docs-dev-guide]
 :revinfo:
+// Shared RISC-V attributes (:company:, :url-riscv:, :doctype: book) from the
+// docs-resources submodule, so this document picks up changes to them centrally.
+// PDF-ONLY: this cross-repo relative include cannot resolve under Antora, which
+// is why it lives in the assembler and never in a page. See MIGRATION.md Step 7.
+include::../docs-resources/global-config.adoc[]
 //:title-logo-image: image:risc-v_logo.png[pdfwidth=3.25in,align=center]
 :description: A working template for documenting RISC-V architecture in asciidoc
-:company: RISC-V.org
-:url-riscv: http://riscv.org
-:doctype: book
 //:preface-title: Preamble
 //:colophon:
 //:appendix-caption: Appendix
@@ -34,7 +36,10 @@ ifndef::spec_short[:spec_short: docs-dev-guide]
 :lang: en
 :listing-caption: Listing
 :sectnums:
-:toc: left
+// `macro` rather than `left` so the toc::[] call below controls placement -- the
+// TOC follows the front matter, as in the template's assembler.
+:toc: macro
+:toc-title: Table of Contents
 :toclevels: 4
 :source-highlighter: pygments
 ifdef::backend-pdf[]
@@ -56,6 +61,27 @@ endif::[]
 //For this book example, I have copied information directly from several Web sites that are hosted by asciidoctor.org and devoted to providing Asciidoc/Asciidoctor documentation, and have authored some explanations. Graphics used are either explicitly available for free, are property of RISC-V International, or were created using Wavedrom.
 
 //This document is released under a Creative Commons Attribution 4.0 International License.
+
+// This repo runs in doc mode, so there is no "Document State" preface to render
+// ahead of the TOC -- see MIGRATION.md "Doc mode".
+toc::[]
+
+[preface]
+== List of figures
+list-of::image[hide_empty_section=true, enhanced_rendering=true]
+
+[preface]
+== List of tables
+list-of::table[hide_empty_section=true, enhanced_rendering=true]
+
+[preface]
+== List of listings
+list-of::listing[hide_empty_section=true, enhanced_rendering=true]
+
+include::../modules/ROOT/pages/copyright.adoc[]
+
+[preface]
+include::../modules/ROOT/pages/contributors.adoc[]
 
 include::../modules/ROOT/pages/intro.adoc[]
 
@@ -82,5 +108,11 @@ include::../modules/ROOT/pages/word-usage.adoc[]
 include::../modules/ROOT/pages/linting.adoc[]
 
 include::../modules/ROOT/pages/build-infrastructure.adoc[]
+
+// The index must precede the bibliography. The index macro is PDF-only (Antora
+// does not generate a back-of-book index), so it lives here in the assembler
+// rather than in a page.
+[index]
+== Index
 
 include::../modules/ROOT/pages/bibliography.adoc[]


### PR DESCRIPTION
Follow-up to #168. That PR merged while this commit was still being written, so
it needs its own.

#168 aligned the tooling with `docs-spec-template`. Comparing the result
file-by-file against the template afterwards showed the tooling matched — 19 of 20
template-owned files byte-identical — but the **document** did not. Two gaps:

## 1. The PDF assembler was missing the template's structure

`UPGRADING.md` calls `src/<spec>.adoc` "the one file that is both": ownership rules
say don't copy it, but the structural requirements live in it. Ours was missing
five elements the template's carries.

| Element | Now renders |
| --- | --- |
| `include::../docs-resources/global-config.adoc[]` | shared `:company:`, `:url-riscv:`, `:doctype:` — local copies removed |
| `toc::[]` (`:toc: left` → `:toc: macro`) | pages 1–4 |
| `list-of::image` / `table` / `listing` | pages 5, 6, 7 |
| `[index] == Index` | page 73, ahead of the bibliography |

Both the `global-config.adoc` include and the `[index]` macro are **PDF-only** and
live in the assembler, never in a page — the cross-repo relative include cannot
resolve under Antora, and Antora generates no back-of-book index (MIGRATION.md
Step 7).

## 2. `contributors.adoc` and `copyright.adoc` were deleted and never replaced

PR #165 removed `src/contributors.adoc` and `src/colophon.adoc`. Both are
recreated as pages, included by the assembler (copyright p8, contributors p9) and
listed in the nav, so each has a single source — rather than the template's
arrangement, which duplicates the copyright text inline in the assembler.

**The contributor list is real and needs curating.** The deleted file still held
the template's `Author1 <required1@email.com>` placeholders, so restoring it
verbatim would have published fake names. These are the actual commit authors from
`git shortlog`, de-duplicated across aliases (`wmat`/`Bill Traynor`, three `elisa`
variants), bots dropped, alphabetised by surname. Names only, no addresses. Git
authorship is not the same as consent to be listed publicly, so please review
before a release.

The license text follows `LICENSE` (CC-BY 4.0).

## Also fixed: the guide contradicted itself

`author-quickstart.adoc` callouts `<4>` and `<5>` stated that contributors and
copyright are "HTML only -- **not** part of the PDF". That was already wrong about
the template — whose assembler includes both — and this change would have made the
guide contradict its own build output. Corrected. Callout `<2>` is deliberately
untouched: the landing page really is HTML-only.

## Nav placement

Both entries are appended as back matter rather than placed up front where the
template puts them. The central playbook's `numbering_rules` for this component
keys chapters off **line numbers** in `nav.adoc` (MIGRATION.md Step 11), so
inserting at the top would silently shift every chapter's numbering on the central
site.

## Verification

- `npm run preview` → exit 0; `contributors.html` and `copyright.html` render
- content-source gate criterion (error/fatal, less the expected `common::` logo) →
  no matches
- `make build-container` → PDF and HTML build; all seven new sections confirmed in
  the extracted PDF text, not just in source

Rebased onto `main` after #168 merged; both builds re-run green on the new base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
