### PR TITLE
Put the title page and front matter first in the nav

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,22 +1,30 @@
-.Authoring and Editing RISC-V Specs
-* xref:intro.adoc[Introduction]
-* xref:authoring.adoc[AsciiDoc authoring for RISC-V contributors]
-* xref:install-tools.adoc[Installing Asciidoctor and using AsciiDoc]
-* xref:author-quickstart.adoc[Template Quickstart: Writing a Spec]
-* xref:antora-structure.adoc[Antora directory structure]
-* xref:a_few_basics.adoc[AsciiDoc basics]
-* xref:index_bib.adoc[Index and Bibliography]
-* xref:graphics.adoc[Graphics]
-* xref:vale.adoc[Vale at RISC-V]
-* xref:style-guidelines.adoc[RISC-V Style Guidelines]
-* xref:writing.adoc[Best Practice]
-* xref:word-usage.adoc[Word Usage Guide]
-* xref:linting.adoc[Linting]
-* xref:build-infrastructure.adoc[Build Infrastructure]
-* xref:bibliography.adoc[Bibliography]
-// Back matter. Appended rather than placed up front (where the template puts
-// them) so the chapter line numbers above do not shift: the central playbook's
-// numbering_rules entry for this component keys chapters off LINE NUMBERS in
-// this file. See MIGRATION.md Step 11.
-* xref:contributors.adoc[Contributors]
-* xref:copyright.adoc[Copyright and license information]
+// Navigation file for Antora
+// https://docs.antora.org/antora/latest/navigation/
+//
+// Update this file to reflect your specification's chapter structure.
+//
+// SECTION NUMBERING: the RISC-V central playbook assigns chapter numbers by the
+// LINE NUMBER of each xref entry below, via its numbering_rules (see ANTORA.md,
+// "Section numbering"). If you add, remove, or reorder entries here -- or edit
+// these header comments -- the line numbers shift, so the matching rule in the
+// central playbook (antora.riscv.org) MUST be updated, or site numbering drifts.
+// To update number, open an issue at https://github.com/riscv-admin/antora-dev.riscv.org
+
+* xref:index.adoc[RISC-V Authoring and Editing Guide]
+** xref:copyright.adoc[Copyright and license information]
+** xref:contributors.adoc[Contributors]
+** xref:intro.adoc[Introduction]
+** xref:authoring.adoc[AsciiDoc authoring for RISC-V contributors]
+** xref:install-tools.adoc[Installing Asciidoctor and using AsciiDoc]
+** xref:author-quickstart.adoc[Template Quickstart: Writing a Spec]
+** xref:antora-structure.adoc[Antora directory structure]
+** xref:a_few_basics.adoc[AsciiDoc basics]
+** xref:index_bib.adoc[Index and Bibliography]
+** xref:graphics.adoc[Graphics]
+** xref:vale.adoc[Vale at RISC-V]
+** xref:style-guidelines.adoc[RISC-V Style Guidelines]
+** xref:writing.adoc[Best Practice]
+** xref:word-usage.adoc[Word Usage Guide]
+** xref:linting.adoc[Linting]
+** xref:build-infrastructure.adoc[Build Infrastructure]
+** xref:bibliography.adoc[Bibliography]

--- a/modules/ROOT/pages/antora-structure.adoc
+++ b/modules/ROOT/pages/antora-structure.adoc
@@ -72,10 +72,11 @@ The `nav.adoc` file defines the navigation sidebar shown in the Antora site.
 
 [source,adoc]
 ----
-* xref:spec-sample.adoc[RISC-V Example Specification]
+* xref:index.adoc[RISC-V Example Specification]
+** xref:copyright.adoc[Copyright and license information]
+** xref:contributors.adoc[Contributors]
 ** xref:intro.adoc[Introduction]
 ** xref:chapter2.adoc[The Second Chapter]
-** xref:contributors.adoc[Contributors]
 ** xref:bibliography.adoc[Bibliography]
 ----
 


### PR DESCRIPTION
Follow-up to #171. That PR merged before this commit arrived, so it needs its own.

Puts the nav in the same order as the template and the PDF: **title page, copyright,
contributors, introduction**, then the chapters.

## What changes

`nav.adoc` now follows the template's structure: the title page (`index.adoc`) is the
top-level entry, and copyright, contributors, the introduction and the chapters are
nested under it, in that order. The PDF already opens title page → copyright →
contributors → Chapter 1.

- **The nav had no title-page entry at all.** `MIGRATION.md` Step 9 asks for one
  ("landing page first").
- **Copyright and contributors were last.** #169 put them there on the stated grounds
  that the central playbook numbers this component's chapters by line number in this
  file. That was never checked, and it's wrong: docs-dev-guide's content source is
  commented out in both `antora.riscv.org` and `antora-dev.riscv.org`, and neither has a
  numbering rule for `docs-guide`. The comment claiming otherwise is replaced by the
  template's own header comment, which warns about line-number coupling in general terms
  — true once this guide is registered centrally.
- The `.Authoring and Editing RISC-V Specs` nav title is dropped. The title-page entry,
  labelled with the component title, takes its place, as in the template.
- **The guide taught the wrong nav.** The example in `antora-structure.adoc` — the one
  template users copy — listed `spec-sample.adoc` as the landing page (the template's is
  `index.adoc`), put contributors after the chapters, and left out copyright. It now
  matches the template's `nav.adoc` entry for entry.

## Verification

- Same page set as before, plus the title page.
- Antora log unchanged: one pre-existing graphviz warning, no errors.
- Rendered sidebar: **RISC-V Authoring and Editing Guide › Copyright and license
  information › Contributors › Introduction › …**, nested under the title page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
